### PR TITLE
feat: Implement custom text input for simulation speed

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <div class="controls">
         <label for="speed-slider">Simulation Speed:</label>
         <input type="range" id="speed-slider" min="0.1" max="2000" value="10" step="0.1">
+        <input type="text" id="speed-text-input">
         <span id="speed-value">10.0x</span>
         <button id="toggle-paths">Toggle Orbit Paths</button>
         <div class="time-info">

--- a/script.js
+++ b/script.js
@@ -7,6 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const simTimeSpan = document.getElementById('sim-time');
     const togglePathsButton = document.getElementById('toggle-paths');
     const tooltip = document.getElementById('tooltip');
+    const speedTextInput = document.getElementById('speed-text-input');
     const infoPanel = document.getElementById('info-panel');
     const infoPanelTitle = document.getElementById('info-panel-title');
     const infoPanelContent = document.getElementById('info-panel-content');
@@ -65,6 +66,11 @@ document.addEventListener('DOMContentLoaded', () => {
     function init() {
         if (infoPanel) { // Ensure panel is hidden initially
             infoPanel.style.display = 'none';
+        }
+
+        // Initialize speed text input
+        if (speedTextInput && speedSlider) {
+            speedTextInput.value = parseFloat(speedSlider.value).toFixed(1);
         }
 
         const solarSystemContainerDiv = document.getElementById('solar-system-container');
@@ -181,7 +187,21 @@ document.addEventListener('DOMContentLoaded', () => {
         speedSlider.addEventListener('input', (e) => {
             simulationSpeed = parseFloat(e.target.value);
             speedValueSpan.textContent = `${simulationSpeed.toFixed(1)}x`;
+            if (speedTextInput) {
+                speedTextInput.value = simulationSpeed.toFixed(1);
+            }
         });
+
+        // Speed text input listeners
+        if (speedTextInput && speedSlider && speedValueSpan) {
+            speedTextInput.addEventListener('keypress', function(event) {
+                if (event.key === 'Enter') {
+                    applySpeedFromTextInput();
+                    event.preventDefault(); 
+                }
+            });
+            speedTextInput.addEventListener('blur', applySpeedFromTextInput);
+        }
 
         togglePathsButton.addEventListener('click', () => {
             pathsVisible = !pathsVisible;
@@ -344,6 +364,32 @@ document.addEventListener('DOMContentLoaded', () => {
             } else {
                 infoPanel.style.display = 'none'; // Hide for Sun or if no body is focused
             }
+        }
+    }
+
+    function applySpeedFromTextInput() {
+        if (!speedTextInput || !speedSlider || !speedValueSpan) return;
+
+        const textValue = parseFloat(speedTextInput.value);
+        const minSpeed = parseFloat(speedSlider.min);
+        const maxSpeed = parseFloat(speedSlider.max);
+
+        if (!isNaN(textValue)) {
+            if (textValue >= minSpeed && textValue <= maxSpeed) {
+                simulationSpeed = textValue;
+                speedSlider.value = textValue; 
+                speedValueSpan.textContent = `${textValue.toFixed(1)}x`;
+            } else {
+                // Value out of range, clamp it
+                const clampedValue = Math.max(minSpeed, Math.min(maxSpeed, textValue));
+                simulationSpeed = clampedValue;
+                speedSlider.value = clampedValue;
+                speedTextInput.value = clampedValue.toFixed(1); 
+                speedValueSpan.textContent = `${clampedValue.toFixed(1)}x`;
+            }
+        } else {
+            // Invalid input, revert to current slider value
+            speedTextInput.value = parseFloat(speedSlider.value).toFixed(1);
         }
     }
 

--- a/style.css
+++ b/style.css
@@ -29,6 +29,16 @@ body {
     vertical-align: middle;
 }
 
+#speed-text-input {
+    width: 60px;
+    margin-left: 5px;
+    padding: 3px;
+    border: 1px solid #ccc;
+    background-color: #333;
+    color: #fff;
+    vertical-align: middle; /* Align with slider and span */
+}
+
 .time-info p {
     margin: 5px 0;
 }


### PR DESCRIPTION
This commit adds a text input field that allows you to set a precise simulation speed with your keyboard.

Key changes:

1.  **HTML/CSS:**
    *   An `<input type="text" id="speed-text-input">` has been added to the controls area, next to the existing speed slider.
    *   Basic styling has been applied for consistent appearance.

2.  **JavaScript:**
    *   The text input is bidirectionally synchronized with the speed slider:
        *   Changing the slider updates the text input's value.
        *   Changing the text input (and pressing Enter or blurring the field) updates the slider's position and the simulation speed.
    *   Input Validation:
        *   The text input value is validated to ensure it's a number.
        *   Values are clamped to the slider's defined min/max range (0.1 to 2000).
        *   If non-numeric input is entered, the field reverts to the current valid speed.
    *   The `simulationSpeed` variable and the `speed-value` display span are updated accordingly.

This feature provides you with more granular control over the simulation's playback speed.